### PR TITLE
Make public UpdateTicks and TokioTasksRuntime

### DIFF
--- a/examples/async_fn.rs
+++ b/examples/async_fn.rs
@@ -1,7 +1,10 @@
 use std::time::Duration;
 
-use bevy::{prelude::{App, ResMut, ClearColor, Color, Commands, Camera2dBundle}, DefaultPlugins};
-use bevy_tokio_tasks::{TokioTasksPlugin, TokioTasksRuntime, TaskContext};
+use bevy::{
+    prelude::{App, Camera2dBundle, ClearColor, Color, Commands, ResMut},
+    DefaultPlugins,
+};
+use bevy_tokio_tasks::{TaskContext, TokioTasksPlugin, TokioTasksRuntime};
 
 static COLORS: [Color; 5] = [
     Color::RED,
@@ -33,7 +36,8 @@ async fn update_colors(mut ctx: TaskContext) {
                 clear_color.0 = COLORS[color_index];
                 println!("Changed clear color to {:?}", clear_color.0);
             }
-        }).await;
+        })
+        .await;
         color_index = (color_index + 1) % COLORS.len();
         tokio::time::sleep(Duration::from_secs(1)).await;
     }

--- a/examples/change_clear_color.rs
+++ b/examples/change_clear_color.rs
@@ -1,6 +1,9 @@
 use std::time::Duration;
 
-use bevy::{prelude::{App, ResMut, ClearColor, Color, Commands, Camera2dBundle}, DefaultPlugins};
+use bevy::{
+    prelude::{App, Camera2dBundle, ClearColor, Color, Commands, ResMut},
+    DefaultPlugins,
+};
 use bevy_tokio_tasks::{TokioTasksPlugin, TokioTasksRuntime};
 
 static COLORS: [Color; 5] = [
@@ -30,7 +33,8 @@ fn demo(runtime: ResMut<TokioTasksRuntime>, mut commands: Commands) {
                     clear_color.0 = COLORS[color_index];
                     println!("Changed clear color to {:?}", clear_color.0);
                 }
-            }).await;
+            })
+            .await;
             color_index = (color_index + 1) % COLORS.len();
             tokio::time::sleep(Duration::from_secs(1)).await;
         }

--- a/examples/shutdown_after_sleep.rs
+++ b/examples/shutdown_after_sleep.rs
@@ -1,4 +1,8 @@
-use bevy::{app::AppExit, prelude::{App, ResMut}, DefaultPlugins};
+use bevy::{
+    app::AppExit,
+    prelude::{App, ResMut},
+    DefaultPlugins,
+};
 use bevy_tokio_tasks::{TokioTasksPlugin, TokioTasksRuntime};
 
 fn main() {
@@ -16,8 +20,12 @@ fn demo(runtime: ResMut<TokioTasksRuntime>) {
         ctx.sleep_updates(120).await;
         println!("Task finished initial wait on tick {}", ctx.current_tick());
         ctx.run_on_main_thread(move |ctx| {
-            println!("Task going to request app exit on tick {}", ctx.current_tick);
+            println!(
+                "Task going to request app exit on tick {}",
+                ctx.current_tick
+            );
             ctx.world.send_event(AppExit {});
-        }).await;
+        })
+        .await;
     });
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,20 +1,35 @@
-use std::{sync::{Arc, atomic::{Ordering, AtomicUsize}}, future::Future};
+use std::{
+    future::Future,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+};
 
-use bevy_app::{Plugin, App};
-use bevy_ecs::{system::Resource, prelude::World};
-use tokio::{runtime::Runtime, task::{JoinHandle}};
+use bevy_app::{App, Plugin};
+use bevy_ecs::{prelude::World, system::Resource};
+use tokio::{runtime::Runtime, task::JoinHandle};
 
 /// An internal struct keeping track of how many ticks have elapsed since the start of the program.
 #[derive(Resource)]
-struct UpdateTicks {
+pub struct UpdateTicks {
     ticks: Arc<AtomicUsize>,
     update_watch_tx: tokio::sync::watch::Sender<()>,
 }
 
 impl UpdateTicks {
+    pub fn new(ticks: Arc<AtomicUsize>, update_watch_tx: tokio::sync::watch::Sender<()>) -> Self {
+        Self {
+            ticks,
+            update_watch_tx,
+        }
+    }
+
     fn increment_ticks(&self) -> usize {
         let new_ticks = self.ticks.fetch_add(1, Ordering::SeqCst).wrapping_add(1);
-        self.update_watch_tx.send(()).expect("Failed to send update_watch channel message");
+        self.update_watch_tx
+            .send(())
+            .expect("Failed to send update_watch channel message");
         new_ticks
     }
 }
@@ -36,7 +51,9 @@ impl Default for TokioTasksPlugin {
             make_runtime: Box::new(|| {
                 let mut runtime = tokio::runtime::Builder::new_multi_thread();
                 runtime.enable_all();
-                runtime.build().expect("Failed to create Tokio runtime for background tasks")
+                runtime
+                    .build()
+                    .expect("Failed to create Tokio runtime for background tasks")
             }),
         }
     }
@@ -47,15 +64,8 @@ impl Plugin for TokioTasksPlugin {
         let ticks = Arc::new(AtomicUsize::new(0));
         let (update_watch_tx, update_watch_rx) = tokio::sync::watch::channel(());
         let runtime = (self.make_runtime)();
-        app.insert_resource(UpdateTicks {
-            ticks: ticks.clone(),
-            update_watch_tx,
-        });
-        app.insert_resource(TokioTasksRuntime::new(
-            ticks,
-            runtime,
-            update_watch_rx,
-        ));
+        app.insert_resource(UpdateTicks::new(ticks.clone(), update_watch_tx));
+        app.insert_resource(TokioTasksRuntime::new(ticks, runtime, update_watch_rx));
         app.add_system(tick_runtime_update);
         // app.add_system_to_stage(self.tick_stage.clone(), tick_runtime_update);
     }
@@ -69,7 +79,7 @@ pub fn tick_runtime_update(world: &mut World) {
     let current_tick = {
         let tick_counter = match world.get_resource::<UpdateTicks>() {
             Some(counter) => counter,
-            None => return
+            None => return,
         };
 
         // Increment update ticks and notify watchers of update tick.
@@ -100,10 +110,11 @@ struct TokioTasksRuntimeInner {
 }
 
 impl TokioTasksRuntime {
-    fn new(
-            ticks: Arc<AtomicUsize>,
-            runtime: Runtime,
-            update_watch_rx: tokio::sync::watch::Receiver<()>) -> Self {
+    pub fn new(
+        ticks: Arc<AtomicUsize>,
+        runtime: Runtime,
+        update_watch_rx: tokio::sync::watch::Receiver<()>,
+    ) -> Self {
         let (update_run_tx, update_run_rx) = tokio::sync::mpsc::unbounded_channel();
 
         Self(Box::new(TokioTasksRuntimeInner {
@@ -123,10 +134,13 @@ impl TokioTasksRuntime {
 
     /// Spawn a task which will run on the background Tokio [`Runtime`] managed by this [`TokioTasksRuntime`]. The
     /// background task is provided a [`TaskContext`] which allows it to do things like
-    /// [sleep for a given number of main thread updates](TaskContext::sleep_updates) or 
+    /// [sleep for a given number of main thread updates](TaskContext::sleep_updates) or
     /// [invoke callbacks on the main Bevy thread](TaskContext::run_on_main_thread).
-    pub fn spawn_background_task<Task, Output, Spawnable>(&self, spawnable_task: Spawnable) -> JoinHandle<Output>
-    where 
+    pub fn spawn_background_task<Task, Output, Spawnable>(
+        &self,
+        spawnable_task: Spawnable,
+    ) -> JoinHandle<Output>
+    where
         Task: Future<Output = Output> + Send + 'static,
         Output: Send + 'static,
         Spawnable: FnOnce(TaskContext) -> Task + Send + 'static,
@@ -146,7 +160,7 @@ impl TokioTasksRuntime {
         while let Ok(runnable) = self.0.update_run_rx.try_recv() {
             let context = MainThreadContext {
                 world,
-                current_tick
+                current_tick,
             };
             runnable(context);
         }
@@ -183,7 +197,10 @@ impl TaskContext {
     /// you instead want to sleep for a given length of wall-clock time, call the normal Tokio sleep
     /// function.
     pub async fn sleep_updates(&mut self, updates_to_sleep: usize) {
-        let target_tick = self.ticks.load(Ordering::SeqCst).wrapping_add(updates_to_sleep);
+        let target_tick = self
+            .ticks
+            .load(Ordering::SeqCst)
+            .wrapping_add(updates_to_sleep);
         while self.ticks.load(Ordering::SeqCst) < target_tick {
             if self.update_watch_rx.changed().await.is_err() {
                 return;
@@ -198,7 +215,7 @@ impl TaskContext {
     pub async fn run_on_main_thread<Runnable, Output>(&mut self, runnable: Runnable) -> Output
     where
         Runnable: FnOnce(MainThreadContext) -> Output + Send + 'static,
-        Output: Send + 'static
+        Output: Send + 'static,
     {
         let (output_tx, output_rx) = tokio::sync::oneshot::channel();
         if self.update_run_tx.send(Box::new(move |ctx| {
@@ -208,6 +225,8 @@ impl TaskContext {
         })).is_err() {
             panic!("Failed to send operation to be run on main thread");
         }
-        output_rx.await.expect("Failed to receive output from operation on main thread")
+        output_rx
+            .await
+            .expect("Failed to receive output from operation on main thread")
     }
 }


### PR DESCRIPTION
I'm trying to define the threads for tokio runtime from a configuration file, but with TokioTasksPlugin I can only define it when adding the plugin, I don't have access to my resources.

### Changes
- change `TokioTasksRuntime::new()` to public
- create `UpdateTicks::new()`
- use `UpdateTicks::new()` when insert resource
- use cargo-fmt to format the code

That way I can create my own TokioTasks plugin.

```
pub struct MyTokioTasksPlugin;

impl Plugin for MyTokioTasksPlugin {
    fn build(&self, app: &mut App) {
        app.add_system(tokio_runtime_system); // any run if check
        app.add_system(bevy_tokio_tasks::tick_runtime_update);
    }
}

fn tokio_runtime_system(mut commands: Commands, my_resource: Res<Config>) { // run once
    let ticks = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
    let (update_watch_tx, update_watch_rx) = tokio::sync::watch::channel(());

    let work_threads = my_resource; // my configuration file

    let runtime = tokio::runtime::Builder::new_multi_thread()
        .worker_threads(work_threads)
        .enable_all()
        .build()
        .expect("Error on build the Tokio Runtime.");

    commands.insert_resource(bevy_tokio_tasks::UpdateTicks::new(
        ticks.clone(),
        update_watch_tx
    );

    commands.insert_resource(bevy_tokio_tasks::TokioTasksRuntime::new(
        ticks,
        runtime,
        update_watch_rx,
    ));
}
```